### PR TITLE
fix: add redirect rules for SPA on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Routes failed when directly accessing https://seonglae-slides.vercel.app/1
Fixed by adding vercel.json


BTW, how do you manage to make pnpm work with vercel? Tried a few methods but still failed. Thanks